### PR TITLE
Add temporal cache to avoid failed URLs (#724)

### DIFF
--- a/http-clients/src/main/java/com/palantir/remoting3/clients/ClientConfiguration.java
+++ b/http-clients/src/main/java/com/palantir/remoting3/clients/ClientConfiguration.java
@@ -84,6 +84,12 @@ public interface ClientConfiguration {
     NodeSelectionStrategy nodeSelectionStrategy();
 
     /**
+     * The amount of time a URL marked as failed should be avoided for subsequent calls. If the
+     * {@link #nodeSelectionStrategy} is ROUND_ROBIN, this must be a positive period of time.
+     */
+    Duration failedUrlCooldown();
+
+    /**
      * The size of one backoff time slot for call retries. For example, an exponential backoff retry algorithm may
      * choose a backoff time in {@code [0, backoffSlotSize * 2^c]} for the c-th retry.
      */
@@ -94,6 +100,10 @@ public interface ClientConfiguration {
         if (meshProxy().isPresent()) {
             checkArgument(maxNumRetries() == 0, "If meshProxy is configured then maxNumRetries must be 0");
             checkArgument(uris().size() == 1, "If meshProxy is configured then uris must contain exactly 1 URI");
+        }
+        if (nodeSelectionStrategy().equals(NodeSelectionStrategy.ROUND_ROBIN)) {
+            checkArgument(!failedUrlCooldown().isNegative() && !failedUrlCooldown().isZero(),
+                    "If nodeSelectionStrategy is ROUND_ROBIN then failedUrlCooldown must be positive");
         }
     }
 

--- a/http-clients/src/main/java/com/palantir/remoting3/clients/ClientConfigurations.java
+++ b/http-clients/src/main/java/com/palantir/remoting3/clients/ClientConfigurations.java
@@ -41,8 +41,9 @@ public final class ClientConfigurations {
     private static final Duration DEFAULT_READ_TIMEOUT = Duration.ofMinutes(10);
     private static final Duration DEFAULT_WRITE_TIMEOUT = Duration.ofMinutes(10);
     private static final Duration DEFAULT_BACKOFF_SLOT_SIZE = Duration.ofMillis(250);
+    private static final Duration DEFAULT_FAILED_URL_COOLDOWN = Duration.ZERO;
     private static final boolean DEFAULT_ENABLE_GCM_CIPHERS = false;
-    private static final NodeSelectionStrategy DEFAULT_RPC_MODE = NodeSelectionStrategy.PIN_UNTIL_ERROR;
+    private static final NodeSelectionStrategy DEFAULT_NODE_SELECTION_STRATEGY = NodeSelectionStrategy.PIN_UNTIL_ERROR;
 
     private ClientConfigurations() {}
 
@@ -51,13 +52,6 @@ public final class ClientConfigurations {
      * empty/absent configuration with the defaults specified as constants in this class.
      */
     public static ClientConfiguration of(ServiceConfiguration config) {
-        return of(config, DEFAULT_RPC_MODE);
-    }
-
-    /**
-     * Like {@link #of(ServiceConfiguration)}, but using the explicitly given NodeSelectionStrategy.
-     */
-    public static ClientConfiguration of(ServiceConfiguration config, NodeSelectionStrategy nodeSelectionStrategy) {
         return ClientConfiguration.builder()
                 .sslSocketFactory(SslSocketFactories.createSslSocketFactory(config.security()))
                 .trustManager(SslSocketFactories.createX509TrustManager(config.security()))
@@ -70,7 +64,8 @@ public final class ClientConfigurations {
                 .proxyCredentials(config.proxy().flatMap(ProxyConfiguration::credentials))
                 .meshProxy(meshProxy(config.proxy()))
                 .maxNumRetries(config.maxNumRetries().orElse(config.uris().size()))
-                .nodeSelectionStrategy(nodeSelectionStrategy)
+                .nodeSelectionStrategy(DEFAULT_NODE_SELECTION_STRATEGY)
+                .failedUrlCooldown(DEFAULT_FAILED_URL_COOLDOWN)
                 .backoffSlotSize(config.backoffSlotSize().orElse(DEFAULT_BACKOFF_SLOT_SIZE))
                 .build();
     }
@@ -93,7 +88,8 @@ public final class ClientConfigurations {
                 .proxyCredentials(Optional.empty())
                 .maxNumRetries(uris.size())
                 .backoffSlotSize(DEFAULT_BACKOFF_SLOT_SIZE)
-                .nodeSelectionStrategy(DEFAULT_RPC_MODE)
+                .nodeSelectionStrategy(DEFAULT_NODE_SELECTION_STRATEGY)
+                .failedUrlCooldown(DEFAULT_FAILED_URL_COOLDOWN)
                 .build();
     }
 

--- a/http-clients/src/test/java/com/palantir/remoting3/clients/ClientConfigurationsTest.java
+++ b/http-clients/src/test/java/com/palantir/remoting3/clients/ClientConfigurationsTest.java
@@ -91,6 +91,22 @@ public final class ClientConfigurationsTest {
                 .hasMessage("If meshProxy is configured then uris must contain exactly 1 URI");
     }
 
+    @Test
+    public void roundRobin_noCooldown() throws Exception {
+        ServiceConfiguration serviceConfig = ServiceConfiguration.builder()
+                .uris(uris)
+                .security(SslConfiguration.of(Paths.get("src/test/resources/trustStore.jks")))
+                .build();
+
+        assertThatThrownBy(() -> ClientConfiguration.builder().from(
+                ClientConfigurations.of(serviceConfig))
+                .nodeSelectionStrategy(NodeSelectionStrategy.ROUND_ROBIN)
+                .failedUrlCooldown(Duration.ofMillis(0))
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("If nodeSelectionStrategy is ROUND_ROBIN then failedUrlCooldown must be positive");
+    }
+
     private ServiceConfiguration meshProxyServiceConfig(List<String> theUris, int maxNumRetries) {
         return ServiceConfiguration.builder()
                 .uris(theUris)

--- a/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/JaxRsClientFailoverTest.java
+++ b/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/JaxRsClientFailoverTest.java
@@ -16,6 +16,7 @@
 
 package com.palantir.remoting3.jaxrs;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
@@ -24,54 +25,51 @@ import static org.junit.Assert.fail;
 import com.google.common.collect.Lists;
 import com.palantir.remoting3.clients.ClientConfiguration;
 import feign.RetryableException;
+import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.theories.DataPoint;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
 
-
+@RunWith(Theories.class)
 public final class JaxRsClientFailoverTest extends TestBase {
 
-    @Rule
-    public final MockWebServer server1 = new MockWebServer();
-    @Rule
-    public final MockWebServer server2 = new MockWebServer();
+    @DataPoint
+    public static final FailoverTestCase CASE = new FailoverTestCase(new MockWebServer(), new MockWebServer(), 0);
 
-    private TestService proxy;
+    @DataPoint
+    public static final FailoverTestCase CASE_WITH_CACHE = new FailoverTestCase(new MockWebServer(),
+            new MockWebServer(), 500);
 
-    @Before
-    public void before() throws Exception {
-        proxy = JaxRsClient.create(TestService.class, AGENT,
-                ClientConfiguration.builder()
-                        .from(createTestConfig(
-                                "http://localhost:" + server1.getPort(),
-                                "http://localhost:" + server2.getPort()))
-                        .maxNumRetries(2)
-                        .build());
+    @Test
+    @Theory
+    public void testConnectionError_performsFailover(FailoverTestCase failoverTestCase) throws IOException {
+        failoverTestCase.server1.shutdown();
+        failoverTestCase.server2.enqueue(new MockResponse().setBody("\"foo\""));
+
+        assertThat(failoverTestCase.getProxy().string(), is("foo"));
     }
 
     @Test
-    public void testConnectionError_performsFailover() throws Exception {
-        server1.shutdown();
-        server2.enqueue(new MockResponse().setBody("\"foo\""));
-
-        assertThat(proxy.string(), is("foo"));
-    }
-
-    @Test
-    public void testConnectionError_performsFailover_concurrentRequests() throws Exception {
+    @Theory
+    public void testConnectionError_performsFailover_concurrentRequests(FailoverTestCase failoverTestCase)
+            throws Exception {
         ExecutorService executorService = Executors.newFixedThreadPool(2);
 
-        server1.shutdown();
+        failoverTestCase.server1.shutdown();
         for (int i = 0; i < 10; i++) {
-            server2.enqueue(new MockResponse().setBody("\"foo\""));
+            failoverTestCase.server2.enqueue(new MockResponse().setBody("\"foo\""));
         }
 
+        TestService proxy = failoverTestCase.getProxy();
         List<Future<String>> things = Lists.newArrayListWithCapacity(10);
         for (int i = 0; i < 10; i++) {
             things.add(executorService.submit(() -> proxy.string()));
@@ -82,10 +80,15 @@ public final class JaxRsClientFailoverTest extends TestBase {
     }
 
     @Test
-    public void testConnectionError_whenOneCallFailsThenSubsequentNewCallsCanStillSucceed() throws Exception {
+    @Theory
+    public void testConnectionError_whenOneCallFailsThenSubsequentNewCallsCanStillSucceed(FailoverTestCase
+            failoverTestCase)
+            throws Exception {
         // Call fails when servers are down.
-        server1.shutdown();
-        server2.shutdown();
+        failoverTestCase.server1.shutdown();
+        failoverTestCase.server2.shutdown();
+
+        TestService proxy = failoverTestCase.getProxy();
         try {
             proxy.string();
             fail();
@@ -95,38 +98,42 @@ public final class JaxRsClientFailoverTest extends TestBase {
 
         // Subsequent call (with the same proxy instance) succeeds.
         MockWebServer anotherServer1 = new MockWebServer(); // Not a @Rule so we can control start/stop/port explicitly
-        anotherServer1.start(server1.getPort());
+        anotherServer1.start(failoverTestCase.server1.getPort());
         anotherServer1.enqueue(new MockResponse().setBody("\"foo\""));
         assertThat(proxy.string(), is("foo"));
         anotherServer1.shutdown();
     }
 
     @Test
-    public void testConnectionError_performsFailoverOnDnsFailure() throws Exception {
-        server1.enqueue(new MockResponse().setBody("\"foo\""));
+    @Theory
+    public void testQosError_performsFailover(FailoverTestCase failoverTestCase) throws Exception {
+        failoverTestCase.server1.enqueue(new MockResponse().setResponseCode(503));
+        failoverTestCase.server1.enqueue(new MockResponse().setBody("\"foo\""));
+        failoverTestCase.server2.enqueue(new MockResponse().setBody("\"bar\""));
+
+        assertThat(failoverTestCase.getProxy().string(), is("bar"));
+    }
+
+    @Test
+    @Theory
+    public void testConnectionError_performsFailoverOnDnsFailure(FailoverTestCase failoverTestCase)
+            throws Exception {
+        failoverTestCase.server1.enqueue(new MockResponse().setBody("\"foo\""));
 
         TestService bogusHostProxy = JaxRsClient.create(TestService.class, AGENT,
                 ClientConfiguration.builder()
                         .from(createTestConfig(
                                 "http://foo-bar-bogus-host.unresolvable:80",
-                                "http://localhost:" + server1.getPort()))
+                                "http://localhost:" + failoverTestCase.server1.getPort()))
                         .maxNumRetries(2)
                         .build());
         assertThat(bogusHostProxy.string(), is("foo"));
-        assertThat(server1.getRequestCount(), is(1));
-    }
-
-    @Test
-    public void testQosError_performsFailover() throws Exception {
-        server1.enqueue(new MockResponse().setResponseCode(503));
-        server1.enqueue(new MockResponse().setBody("\"foo\""));
-        server2.enqueue(new MockResponse().setBody("\"bar\""));
-
-        assertThat(proxy.string(), is("bar"));
+        assertThat(failoverTestCase.server1.getRequestCount(), is(1));
     }
 
     @Test
     public void testQosError_performsRetryWithOneNode() throws Exception {
+        MockWebServer server1 = new MockWebServer();
         server1.enqueue(new MockResponse().setResponseCode(503));
         server1.enqueue(new MockResponse().setBody("\"foo\""));
 
@@ -136,5 +143,70 @@ public final class JaxRsClientFailoverTest extends TestBase {
                 .build());
 
         assertThat(anotherProxy.string(), is("foo"));
+    }
+
+    @Test
+    public void testQosError_performsRetryWithOneNodeAndCache() throws Exception {
+        MockWebServer server1 = new MockWebServer();
+        server1.enqueue(new MockResponse().setResponseCode(503));
+        server1.enqueue(new MockResponse().setBody("\"foo\""));
+
+        TestService anotherProxy = JaxRsClient.create(TestService.class, AGENT, ClientConfiguration.builder()
+                .from(createTestConfig("http://localhost:" + server1.getPort()))
+                .maxNumRetries(2)
+                .failedUrlCooldown(Duration.ofMillis(500))
+                .build());
+
+        assertThat(anotherProxy.string(), is("foo"));
+    }
+
+    @Test
+    public void testCache_recovery() throws Exception {
+        MockWebServer server1 = new MockWebServer();
+
+        TestService anotherProxy = JaxRsClient.create(TestService.class, AGENT, ClientConfiguration.builder()
+                .from(createTestConfig("http://localhost:" + server1.getPort()))
+                .maxNumRetries(1)
+                .failedUrlCooldown(Duration.ofMillis(500))
+                .build());
+
+        server1.shutdown();
+
+        // Fail the request, ensuring that the URL is added to the cache
+        assertThatExceptionOfType(RetryableException.class).isThrownBy(() -> anotherProxy.string());
+
+        // Allow the cache to clear
+        Thread.sleep(1000);
+
+        MockWebServer anotherServer1 = new MockWebServer(); // Not a @Rule so we can control start/stop/port explicitly
+        anotherServer1.start(server1.getPort());
+
+        anotherServer1.enqueue(new MockResponse().setResponseCode(503));
+        anotherServer1.enqueue(new MockResponse().setBody("\"foo\""));
+        assertThat(anotherProxy.string(), is("foo"));
+        anotherServer1.shutdown();
+    }
+
+    private static class FailoverTestCase {
+        private final MockWebServer server1;
+        private final MockWebServer server2;
+        private final long duration;
+
+        FailoverTestCase(MockWebServer server1, MockWebServer server2, long duration) {
+            this.server1 = server1;
+            this.server2 = server2;
+            this.duration = duration;
+        }
+
+        public TestService getProxy() {
+            return JaxRsClient.create(TestService.class, AGENT,
+                    ClientConfiguration.builder()
+                            .from(createTestConfig(
+                                    "http://localhost:" + server1.getPort(),
+                                    "http://localhost:" + server2.getPort()))
+                            .maxNumRetries(2)
+                            .failedUrlCooldown(Duration.ofMillis(duration))
+                            .build());
+        }
     }
 }

--- a/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/TestBase.java
+++ b/jaxrs-clients/src/test/java/com/palantir/remoting3/jaxrs/TestBase.java
@@ -29,7 +29,7 @@ public abstract class TestBase {
 
     protected static final UserAgent AGENT = UserAgent.of(UserAgent.Agent.of("test", "0.0.1"));
 
-    protected final ClientConfiguration createTestConfig(String... uri) {
+    protected static final ClientConfiguration createTestConfig(String... uri) {
         SslConfiguration sslConfig = SslConfiguration.of(Paths.get("src/test/resources/trustStore.jks"));
         return ClientConfigurations.of(
                 ImmutableList.copyOf(uri),

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/OkHttpClients.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/OkHttpClients.java
@@ -124,7 +124,8 @@ public final class OkHttpClients {
         TaggedMetricRegistry registry = DefaultTaggedMetricRegistry.getDefault();
 
         // Routing
-        UrlSelectorImpl urlSelector = UrlSelectorImpl.create(config.uris(), randomizeUrlOrder);
+        UrlSelectorImpl urlSelector = UrlSelectorImpl.createWithFailedUrlCooldown(config.uris(), randomizeUrlOrder,
+                config.failedUrlCooldown());
         if (config.meshProxy().isPresent()) {
             // TODO(rfink): Should this go into the call itself?
             client.addInterceptor(new MeshProxyInterceptor(config.meshProxy().get()));

--- a/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/UrlSelector.java
+++ b/okhttp-clients/src/main/java/com/palantir/remoting3/okhttp/UrlSelector.java
@@ -51,4 +51,10 @@ public interface UrlSelector {
      * okhttp3.Request#url} does.
      */
     List<HttpUrl> getBaseUrls();
+
+    /**
+     * Indicates that a call against the given URL has failed. Implementations can use failure statistics to determine
+     * which hosts may be unavailable and should be avoided for future calls.
+     */
+    void markAsFailed(HttpUrl failedUrl);
 }

--- a/retrofit2-clients/src/test/java/com/palantir/remoting3/retrofit2/Retrofit2ClientFailoverTest.java
+++ b/retrofit2-clients/src/test/java/com/palantir/remoting3/retrofit2/Retrofit2ClientFailoverTest.java
@@ -21,49 +21,45 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.palantir.remoting3.clients.ClientConfiguration;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.theories.DataPoint;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
 
-
+@RunWith(Theories.class)
 public final class Retrofit2ClientFailoverTest extends TestBase {
 
-    @Rule
-    public final MockWebServer server1 = new MockWebServer();
-    @Rule
-    public final MockWebServer server2 = new MockWebServer();
+    @DataPoint
+    public static final FailoverTestCase CASE = new FailoverTestCase(new MockWebServer(), new MockWebServer(), 0);
 
-    private TestService proxy;
+    @DataPoint
+    public static final FailoverTestCase CASE_WITH_CACHE = new FailoverTestCase(new MockWebServer(),
+            new MockWebServer(), 500);
 
-    @Before
-    public void before() throws Exception {
-        proxy = Retrofit2Client.create(
-                TestService.class, AGENT,
-                ClientConfiguration.builder()
-                        .from(createTestConfig(
-                                String.format("http://%s:%s/api/", server1.getHostName(), server1.getPort()),
-                                String.format("http://%s:%s/api/", server2.getHostName(), server2.getPort())))
-                        .maxNumRetries(2)  // need 2 retries because URL order is not deterministic
-                        .build());
+    @Test
+    @Theory
+    public void testConnectionError_performsFailover(FailoverTestCase failoverTestCase) throws IOException {
+        failoverTestCase.server1.shutdown();
+        failoverTestCase.server2.enqueue(new MockResponse().setBody("\"pong\""));
+        assertThat(failoverTestCase.getProxy().get().execute().body()).isEqualTo("pong");
     }
 
     @Test
-    public void testConnectionError_performsFailover() throws IOException {
-        server1.shutdown();
-        server2.enqueue(new MockResponse().setBody("\"pong\""));
-        assertThat(proxy.get().execute().body()).isEqualTo("pong");
-    }
+    @Theory
+    public void testConnectionError_whenOneCallFailsThenSubsequentNewCallsCanStillSucceed(
+            FailoverTestCase failoverTestCase) throws Exception {
+        failoverTestCase.server1.shutdown();
+        failoverTestCase.server2.shutdown();
 
-    @Test
-    public void testConnectionError_whenOneCallFailsThenSubsequentNewCallsCanStillSucceed() throws Exception {
-        server1.shutdown();
-        server2.shutdown();
+        TestService proxy = failoverTestCase.getProxy();
 
         assertThatThrownBy(() -> proxy.get().execute())
                 .isInstanceOf(IOException.class)
@@ -71,44 +67,33 @@ public final class Retrofit2ClientFailoverTest extends TestBase {
 
         // Subsequent call (with the same proxy instance) succeeds.
         MockWebServer anotherServer1 = new MockWebServer(); // Not a @Rule so we can control start/stop/port explicitly
-        anotherServer1.start(server1.getPort());
+        anotherServer1.start(failoverTestCase.server1.getPort());
         anotherServer1.enqueue(new MockResponse().setBody("\"foo\""));
         assertThat(proxy.get().execute().body()).isEqualTo("foo");
         anotherServer1.shutdown();
     }
 
     @Test
-    public void testConnectionError_performsFailoverOnDnsFailure() throws Exception {
-        server1.enqueue(new MockResponse().setBody("\"foo\""));
+    @Theory
+    public void testQosError_performsFailover_forSynchronousOperation(FailoverTestCase failoverTestCase)
+            throws Exception {
+        failoverTestCase.server1.enqueue(new MockResponse().setResponseCode(503));
+        failoverTestCase.server1.enqueue(new MockResponse().setBody("\"foo\""));
+        failoverTestCase.server2.enqueue(new MockResponse().setBody("\"bar\""));
 
-        TestService bogusHostProxy = Retrofit2Client.create(TestService.class, AGENT,
-                ClientConfiguration.builder()
-                        .from(createTestConfig(
-                                "http://foo-bar-bogus-host.unresolvable:80",
-                                "http://localhost:" + server1.getPort()))
-                        .maxNumRetries(2)
-                        .build());
-        assertThat(bogusHostProxy.get().execute().body()).isEqualTo("foo");
-        assertThat(server1.getRequestCount()).isEqualTo(1);
+        assertThat(failoverTestCase.getProxy().get().execute().body()).isEqualTo("bar");
     }
 
     @Test
-    public void testQosError_performsFailover_forSynchronousOperation() throws Exception {
-        server1.enqueue(new MockResponse().setResponseCode(503));
-        server1.enqueue(new MockResponse().setBody("\"foo\""));
-        server2.enqueue(new MockResponse().setBody("\"bar\""));
-
-        assertThat(proxy.get().execute().body()).isEqualTo("bar");
-    }
-
-    @Test
-    public void testQosError_performsFailover_forAsynchronousOperation() throws Exception {
-        server1.enqueue(new MockResponse().setResponseCode(503));
-        server1.enqueue(new MockResponse().setBody("\"foo\""));
-        server2.enqueue(new MockResponse().setBody("\"bar\""));
+    @Theory
+    public void testQosError_performsFailover_forAsynchronousOperation(FailoverTestCase failoverTestCase)
+            throws Exception {
+        failoverTestCase.server1.enqueue(new MockResponse().setResponseCode(503));
+        failoverTestCase.server1.enqueue(new MockResponse().setBody("\"foo\""));
+        failoverTestCase.server2.enqueue(new MockResponse().setBody("\"bar\""));
 
         CompletableFuture<String> future = new CompletableFuture<>();
-        proxy.get().enqueue(new Callback<String>() {
+        failoverTestCase.getProxy().get().enqueue(new Callback<String>() {
             @Override
             public void onResponse(Call<String> call, Response<String> response) {
                 future.complete(response.body());
@@ -123,7 +108,24 @@ public final class Retrofit2ClientFailoverTest extends TestBase {
     }
 
     @Test
+    @Theory
+    public void testConnectionError_performsFailoverOnDnsFailure(FailoverTestCase failoverTestCase) throws Exception {
+        failoverTestCase.server1.enqueue(new MockResponse().setBody("\"foo\""));
+
+        TestService bogusHostProxy = Retrofit2Client.create(TestService.class, AGENT,
+                ClientConfiguration.builder()
+                        .from(createTestConfig(
+                                "http://foo-bar-bogus-host.unresolvable:80",
+                                "http://localhost:" + failoverTestCase.server1.getPort()))
+                        .maxNumRetries(2)
+                        .build());
+        assertThat(bogusHostProxy.get().execute().body()).isEqualTo("foo");
+        assertThat(failoverTestCase.server1.getRequestCount()).isEqualTo(1);
+    }
+
+    @Test
     public void testQosError_performsRetryWithOneNode_forSynchronousOperation() throws Exception {
+        MockWebServer server1 = new MockWebServer();
         server1.enqueue(new MockResponse().setResponseCode(503));
         server1.enqueue(new MockResponse().setBody("\"foo\""));
 
@@ -136,7 +138,23 @@ public final class Retrofit2ClientFailoverTest extends TestBase {
     }
 
     @Test
+    public void testQosError_performsRetryWithOneNodeAndCache_forSynchronousOperation() throws Exception {
+        MockWebServer server1 = new MockWebServer();
+        server1.enqueue(new MockResponse().setResponseCode(503));
+        server1.enqueue(new MockResponse().setBody("\"foo\""));
+
+        TestService anotherProxy = Retrofit2Client.create(TestService.class, AGENT, ClientConfiguration.builder()
+                .from(createTestConfig("http://localhost:" + server1.getPort()))
+                .maxNumRetries(2)
+                .failedUrlCooldown(Duration.ofMillis(500))
+                .build());
+
+        assertThat(anotherProxy.get().execute().body()).isEqualTo("foo");
+    }
+
+    @Test
     public void testQosError_performsRetryWithOneNode_forAsynchronousOperation() throws Exception {
+        MockWebServer server1 = new MockWebServer();
         server1.enqueue(new MockResponse().setResponseCode(503));
         server1.enqueue(new MockResponse().setBody("\"foo\""));
 
@@ -159,5 +177,85 @@ public final class Retrofit2ClientFailoverTest extends TestBase {
         });
 
         assertThat(future.get()).isEqualTo("foo");
+    }
+
+    @Test
+    public void testQosError_performsRetryWithOneNodeAndCache_forAsynchronousOperation() throws Exception {
+        MockWebServer server1 = new MockWebServer();
+        server1.enqueue(new MockResponse().setResponseCode(503));
+        server1.enqueue(new MockResponse().setBody("\"foo\""));
+
+        TestService anotherProxy = Retrofit2Client.create(TestService.class, AGENT, ClientConfiguration.builder()
+                .from(createTestConfig("http://localhost:" + server1.getPort()))
+                .maxNumRetries(2)
+                .failedUrlCooldown(Duration.ofMillis(500))
+                .build());
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+        anotherProxy.get().enqueue(new Callback<String>() {
+            @Override
+            public void onResponse(Call<String> call, Response<String> response) {
+                future.complete(response.body());
+            }
+
+            @Override
+            public void onFailure(Call<String> call, Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+        });
+
+        assertThat(future.get()).isEqualTo("foo");
+    }
+
+    @Test
+    public void testCache_recovery() throws Exception {
+        MockWebServer server1 = new MockWebServer();
+
+        TestService anotherProxy = Retrofit2Client.create(TestService.class, AGENT, ClientConfiguration.builder()
+                .from(createTestConfig("http://localhost:" + server1.getPort()))
+                .maxNumRetries(1)
+                .failedUrlCooldown(Duration.ofMillis(500))
+                .build());
+
+        server1.shutdown();
+
+        // Fail the request, ensuring that the URL is added to the cache
+        assertThatThrownBy(() -> anotherProxy.get().execute())
+                .isInstanceOf(IOException.class)
+                .hasMessageStartingWith("Failed to complete the request due to an IOException");
+
+        // Allow the cache to clear
+        Thread.sleep(1000);
+
+        MockWebServer anotherServer1 = new MockWebServer(); // Not a @Rule so we can control start/stop/port explicitly
+        anotherServer1.start(server1.getPort());
+
+        anotherServer1.enqueue(new MockResponse().setResponseCode(503));
+        anotherServer1.enqueue(new MockResponse().setBody("\"foo\""));
+        assertThat(anotherProxy.get().execute().body()).isEqualTo("foo");
+        anotherServer1.shutdown();
+    }
+
+    private static class FailoverTestCase {
+        private final MockWebServer server1;
+        private final MockWebServer server2;
+        private final long duration;
+
+        FailoverTestCase(MockWebServer server1, MockWebServer server2, long duration) {
+            this.server1 = server1;
+            this.server2 = server2;
+            this.duration = duration;
+        }
+
+        public TestService getProxy() {
+            return Retrofit2Client.create(TestService.class, AGENT,
+                    ClientConfiguration.builder()
+                            .from(createTestConfig(
+                                    String.format("http://%s:%s/api/", server1.getHostName(), server1.getPort()),
+                                    String.format("http://%s:%s/api/", server2.getHostName(), server2.getPort())))
+                            .maxNumRetries(2)  // need 2 retries because URL order is not deterministic
+                            .failedUrlCooldown(Duration.ofMillis(duration))
+                            .build());
+        }
     }
 }

--- a/retrofit2-clients/src/test/java/com/palantir/remoting3/retrofit2/TestBase.java
+++ b/retrofit2-clients/src/test/java/com/palantir/remoting3/retrofit2/TestBase.java
@@ -29,7 +29,7 @@ abstract class TestBase {
 
     protected static final UserAgent AGENT = UserAgent.of(UserAgent.Agent.of("test", "0.0.1"));
 
-    final ClientConfiguration createTestConfig(String... uri) {
+    protected static final ClientConfiguration createTestConfig(String... uri) {
         SslConfiguration sslConfig = SslConfiguration.of(Paths.get("src/test/resources/trustStore.jks"));
         return ClientConfigurations.of(
                 ImmutableList.copyOf(uri),


### PR DESCRIPTION
* Add temporal cache to skip failed URLs (required for round robin strategies).

* Remove test lines

* Update dependencies

* First bit of PR comments

* Expose cool down specification. Add tests.

* Clean up versions; bump test cache duration to not clear nearly instantaneously

* Test timeouts that exceed backoff period

* DataPoint/Theory test isolation

* DFox PR comments

* Comprehensive testing

* Add base URL to failed cache. Add test that waits for cache to clear

* Style